### PR TITLE
Terraref extractor class

### DIFF
--- a/terrautils/sensors.py
+++ b/terrautils/sensors.py
@@ -9,6 +9,9 @@ date_p = '{}-{}-{}'.format(year_p, month_p, day_p)
 time_p = '([0-1]\d|2[0-3])-([0-5]\d)-([0-5]\d)'
 full_time_p = '([0-1]\d|2[0-3])-([0-5]\d)-([0-5]\d)-(\d{3})'
 full_date_p = '{}__{}'.format(date_p, full_time_p)
+filename_level_p = '(raw|lv1|lv2)'
+path_level_p = '(raw_data|Level_1|Level_2)'
+
 
 STATIONS = {
     'danforth': {
@@ -17,15 +20,7 @@ STATIONS = {
         'raw_data': {
             'ddpscIndoorSuite': {
                 'template': '{base}/{station}/{level}/'
-                            '{sensor}/{snapshotID}/{filename}',  
-                'pattern': '{snapshotID}/{suffix}.png'
-            }
-        },
-
-        'Level_1': {
-            'plantcv': {
-                'template': '{base}/{station}{level}/'
-                            '{sensor}/{time}/{filename}',
+                            '{sensor}/{snapshotID}/{filename}',
                 'pattern': 'avg_traits.csv'
             }
         }
@@ -56,18 +51,76 @@ STATIONS = {
         'title': 'MAC Field Scanner',
         'raw_data': {
             'co2Sensor': {
+                "fixed_metadata_datasetid": "5873a9924f0cad7d8131b648",
                 'template': '{base}/{station}/{level}/'
                             '{sensor}/{date}/{time}/{filename}',
                 'pattern': '([0-9a-f]){8}-([0-9a-f]){4}-([0-9'
                            'a-f]){4}-([0-9a-f]){4}-([0-9a-f])'
                            '{12}_(metadata.json|rawData0000.bin)'
             },
-
+            
+            'stereoTop': {
+                "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e"
+            },
+            
+            'flirIrCamera': {
+                "fixed_metadata_datasetid": "5873a7184f0cad7d8131994a"
+            },
+            
+            "cropCircle": {
+                "fixed_metadata_datasetid": "5873a7ed4f0cad7d8131a2e7"
+            },
+            
+            "irrigation": {
+                "fixed_metadata_datasetid": "TBD"
+            },
+            
             'EnvironmentLogger': {
                 'template': '{base}/{station}/{level}/'
                             '{sensor}/{date}/{filename}',
-                'pattern': '{timestamp}_environment_logger.json'
+                'pattern': '{timestamp}_environment_logger.json',
+                'fixed_metadata_datasetid': 'TBD'
             },
+            
+            "lightning": {
+                "fixed_metadata_datasetid": "TBD"
+            },
+            
+            "ndviSensor": {
+                "fixed_metadata_datasetid": "5873a8f64f0cad7d8131af54"
+            },
+            
+            "parSensor": {
+                "fixed_metadata_datasetid": "5873a8ce4f0cad7d8131ad86"
+            },
+            
+            "priSensor": {
+                "fixed_metadata_datasetid": "5873a9174f0cad7d8131b09a"
+            },
+            
+            "ps2Top": {
+                "fixed_metadata_datasetid": "5873a84b4f0cad7d8131a73d"
+            },
+            
+            "scanner3DTop": {
+                "fixed_metadata_datasetid": "5873a7444f0cad7d81319b2b"
+            },
+            
+            "stereoTop": {
+                "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e"
+            },
+            
+            "SWIR": {
+                "fixed_metadata_datasetid": "5873a79e4f0cad7d81319f5f"
+            },
+            
+            "VNIR": {
+                "fixed_metadata_datasetid": "5873a7bb4f0cad7d8131a0b7"
+            },
+            
+            "weather": {
+                  "fixed_metadata_datasetid": "TBD"
+            }
         },
 
         'Level_1': {
@@ -108,7 +161,6 @@ STATIONS = {
                 'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
             },
 
-            # {date}_{time}_environmentlogger.nc
             'EnvironmentLogger': {
                 'template': '{base}/{station}/{level}/'
                             '{sensor}/{date}/{filename}',
@@ -149,6 +201,12 @@ STATIONS = {
             },
         },
     },
+}
+
+LV_CONV = {
+    'raw_data': 'raw',
+    'Level_1': 'lv1',
+    'Level_2': 'lv2'
 }
 
 
@@ -192,7 +250,7 @@ def plot_attachment_name(sitename, sensor, date, product):
     """
 
     root, ext = os.path.splitext(product)
-    return "{}-{}-{}.{}".format(sitename, sensor, date, ext) 
+    return "{}-{}-{}.{}".format(sitename, sensor, date, ext)
 
 
 class Sensors():
@@ -209,25 +267,31 @@ class Sensors():
         self.sensor = sensor
 
 
+    def _level_names(self, level):
+        """Convert level path name to level file name."""
+
+        return LV_CONV[level]
+
+
     def get_sensor_path(self, timestamp, sensor='', filename='',
                         opts=None, ext=''):
         """Get the appropritate path for writing sensor data
-    
+
         Args:
           time (datetime str): timestamp string
           filename (str): option filename, must match sensor pattern
-          
+
         Returns:
           (str) full path to file
-    
+
         Notes:
           When no filename is given, get_sensor_path returns the desired
           path with pre-defined, well-known filename. If filename is not
           given and no pre-defined filename exists, then a RuntimeError
           is raised.
-    
+
           If a filename is supplied, it must match a pre-defined pattern.
-          A RuntimeError is raised if the filename does not match the 
+          A RuntimeError is raised if the filename does not match the
           pattern.
         """
 
@@ -242,63 +306,72 @@ class Sensors():
         if opts:
             opts = '_'.join(['']+opts)
         else:
-           opts = ''
-    
+            opts = ''
+
         # split timestamp into date and hour-minute-second components
         date, hms = timestamp.split('__')
 
         try:
             s = STATIONS[self.site][self.level][sensor]
-                
+
         except KeyError:
             raise RuntimeError('The station, level or sensor given does'
                                ' not exist')
 
         # TODO pattern should be completed with regex string using format
         if filename:
-            result = re.match(exact_p(s['pattern']), filename)
-            #if result==None:
-            #    raise RuntimeError('The filename given does not match '
-            #                       'the correct pattern')
+            try:
+                pattern = exact_p(s['pattern']).format(sensor='\D*',
+                              level='(raw|lv1|lv2)', station='\D*',
+                              date=date_p, time=full_time_p,
+                              timestamp=full_date_p, opts='\D*')
+            except KeyError:
+                raise RuntimeError('Some fields from the pattern '
+                                   'are not available')
+
+            result = re.match(pattern, filename)
+            if result==None:
+                raise RuntimeError('The filename given does not match '
+                                   'the correct pattern')
 
         # TODO check that all fields from patterns are available
         # TODO write the _level_name function (maps Level_1 to lv1, etc)
         else:
-            filename = s['pattern'].format(station=self.station, 
+            filename = s['pattern'].format(station=self.station,
                     level=self._level_names(self.level), sensor=sensor,
                     timestamp=timstamp, date=date, time=hms,
                     opts=opts)
-                                           
-        # TODO split extension with os.path function than do 
+
+        # TODO split extension with os.path function than do
         # a string match and replace
         if ext:
-            filename = filename.split('.')[0] + ext
+            filename = os.path.splitext(filename)[0] + ext
 
         path = s['template'].format(base=self.base, station=self.station,
                                     level=self.level, sensor=self.sensor,
                                     timestamp=timstamp, date=date, time=hms,
                                     filename=filename)
         return path
-    
+
 
     def get_sensor_path_by_dataset(self, datasetname, sensor='',
                                    ext='', opts=None, hms=None):
         """Get the appropritate path for writing sensor data
-    
+
         Args:
           station (str): abbreviated name of the site
           level (str): data level (raw_data | Level_1 | Level_2)
-          datasetname (sensor - date__timestamp str): 
+          datasetname (sensor - date__timestamp str):
               e.g. VNIR - 2017-06-28__23-48-28-435
           sensor (str): sensor name, may be a product name for Level_1
           opts (list of strs): any suffixes to apply to generated filename
-          hms (str): allows one to add/override a timestamp 
+          hms (str): allows one to add/override a timestamp
           if not included in datasetname (e.g. EnvironmentLogger)
-    
+
         Returns:
           (str) full path
         """
-    
+
         # Split dataset into sensorname and timestamp portions
         if datasetname.find(" - ") > -1:
             sensorname, time = datasetname.split(" - ")
@@ -318,68 +391,82 @@ class Sensors():
         if hms:
             time = date + "__" + hms
 
-        # Override dataset sensor name with provided name if given 
+        # Override dataset sensor name with provided name if given
         # (e.g. use timestamp of raw while getting Level_1 output)
         if sensor == "":
             sensor = sensorname
-    
+
         return self.get_sensor_path(time, sensor=sensor, opts=opts, ext=ext)
+
+
+    def get_fixed_datasetid_for_sensor(site, level, sensor):
+        """ Returns the Clowder dataset ID for the
+            fixed sensor information
+        """
+        if not site:
+            site = self.site
+        if not level:
+            level = self.level
+        if not sensor:
+            sensor = self.sensor
+
+        return STATIONS[site][level][sensor]['fixed_metadata_datasetid']
 
 
     def create_sensor_path(self, path):
         """Create path if does not exist."""
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
-    
-    
+
+
     def get_sensors(self, station):
         """Get all sensors for a given station."""
         return STATIONS[self.station]['sensors'].keys()
-    
-    
+
+
     def get_sites(self):
         """Get all sites (stations) listed."""
         return STATIONS.keys()
-    
-    
+
+
     def check_site(self, station):
         """ Checks for valid station given the station name, and return its
         path in the file system.
         """
-    
+
         if not os.path.exists(self.base):
             raise InvalidUsage('Could not find data, try setting '
                                'TERRAREF_BASE environmental variable')
-    
+
         sitepath = os.path.join(self.base, self.station)
         if not os.path.exists(sitepath):
             raise InvalidUsage('unknown site', payload={'site': station})
-    
+
         return sitepath
-    
-    
+
+
     def check_sensor(station, sensor, date=None):
         """ Checks for valid sensor with optional date, and return its path
         in the file system.
         """
-    
+
         sitepath = check_site(station)
-    
+
         sensorpath = os.path.join(sitepath, 'Level_1', sensor)
         if not os.path.exists(sensorpath):
             raise InvalidUsage('unknown sensor',
                                payload={'site': station, 'sensor': sensor})
-    
+
         if not date:
             return sensorpath
-    
+
         datepath = os.path.join(sensorpath, date)
         print("datepath = {}".format(datepath))
         if not os.path.exists(datepath):
             raise InvalidUsage('sensor data not available for given date',
                                payload={'site': station, 'sensor': sensor,
                                         'date': date})
-    
+
         return datepath
-    
-    
+
+

--- a/terrautils/sensors.py
+++ b/terrautils/sensors.py
@@ -2,47 +2,6 @@ import os
 import re
 
 
-
-if os.path.exists('/projects/arpae/terraref/sites'):
-    TERRAREF_BASE = '/projects/arpae/terraref/sites'
-else:
-    TERRAREF_BASE = '/home/extractor/sites'
-
-TERRAREF_BASE = os.environ.get('TERRAREF_BASE', TERRAREF_BASE)
-
-
-"""
-{
-    "site short (disk) name": {
-        "sitename": "site long name"
-        "sensors": {
-            "sensor short name": {
-                "grouping": { "either unstitched (raw outputs) or stitched (full field clippable mosaics)"
-                    "template": "location on disk after site base (e.g. /home/extractor/sites/ua-mac/raw/PATHNAME)
-                    "level": "data product level, default level (e.g. raw_data)
-                    "day_folder": "whether there is a date folder between template and data, default True"
-                    "timestamp_folder": "whether there is a timestamp folder between template and data, default True"
-                    "patterns": ["basic representations of filename pattern if unusual
-                        TZUTC = YYYY-MM-DDTHH-MM-SSZ"
-                        SNAPID = Danforth snapshot ID (e.g. 295351)
-                        UID = some distinct ID number that may vary per dataset
-                    ],
-                    "suffixes" ["basic representations of filename pattern if using extractors.get_output_filename
-                        terrautils.extractors.get_output_filename(
-                            "dataset (e.g. stereoTop - 2000-01-01__01-01-01-000)",
-                            outextension=suffixes[i].split('.')[1],
-                            site="uamac",
-                            opts=[suffixes[i].split('.')[0]]
-                        )
-                    ]
-                },
-            }
-        }
-    }
-}
-"""
-
-
 year_p = '(20\d\d)'
 month_p = '(0[1-9]|1[0-2])'
 day_p = '(10|20|[0-2][1-9]|3[01])'
@@ -53,183 +12,162 @@ full_date_p = '{}__{}'.format(date_p, full_time_p)
 
 STATIONS = {
     'danforth': {
-        'sitename': 'Danforth Plant Science Center '
+        'title': 'Danforth Plant Science Center '
                     'Bellweather Phenotyping Facility',
-        'derived_data': {
-        },
         'raw_data': {
             'ddpscIndoorSuite': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
+                'template': '{base}/{station}/{level}/'
                             '{sensor}/{snapshotID}/{filename}',  
-                'filename': '{snapshotID}/{suffix}.png'
+                'pattern': '{snapshotID}/{suffix}.png'
             }
         },
-        'plantcv': {
-            'template': '{TERRAREF_BASE}/{station}{level}/'
-                        '{sensor}/{time}/{filename}',
-            'filename': 'avg_traits.csv'
+
+        'Level_1': {
+            'plantcv': {
+                'template': '{base}/{station}{level}/'
+                            '{sensor}/{time}/{filename}',
+                'pattern': 'avg_traits.csv'
+            }
         }
     },
 
     'ksu': {
-        'sitename': 'Ashland Bottoms KSU Field Site',
+        'title': 'Ashland Bottoms KSU Field Site',
         'raw_data': {
         },
 
         'Level_1': {
             'dsm': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
+                'template': '{base}/{station}/{level}/'
                             '{sensor}/{filename}',
-                'filename': '{time}_DSM_16ASH-TERRA.tif'
+                'pattern': '{time}_DSM_16ASH-TERRA.tif'
             },
             'rededge': {
-                'template': '{TERRAREF_BASE}/{station}/{Level_1}/'
+                'template': '{base}/{station}/{Level_1}/'
                             '{sensor}/{filename}',
-                'filename': '{time}_BGREN_16ASH-TERRA'
+                'pattern': '{time}_BGREN_16ASH-TERRA'
             }
         },
         'Level_2': {
         }
     },
+
     'ua-mac': {
-        'sitename': 'MAC Field Scanner',
-        'Level_1': {
-            'rgb_fullfield': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{filename}',
-                'filename': 'stereoTop_fullfield.tif'
-            },
-            'rgb_fullfield_1pct': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{filename}',
-                'filename': 'stereoTop_fullfield_1pct.tif'
-            },
-            'flirIrCamera': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
+        'title': 'MAC Field Scanner',
+        'raw_data': {
+            'co2Sensor': {
+                'template': '{base}/{station}/{level}/'
                             '{sensor}/{date}/{time}/{filename}',
                 'pattern': '([0-9a-f]){8}-([0-9a-f]){4}-([0-9'
                            'a-f]){4}-([0-9a-f]){4}-([0-9a-f])'
-                           '{12}.(png|tif)'
+                           '{12}_(metadata.json|rawData0000.bin)'
             },
-            'stereoTop_geotiff': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': ('stereoTop_lv1_{}__{}_uamac_(left|right)'
-                            '.(jpg|tif)').format(date_p, full_time_p)
-            },
-            'stereoTop_canopyCover': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'filename': 'CanopyCoverTraits.csv'
-            },
-            'texture_analysis': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': 'stereoTop_lv1_{}__{}_uamac_texture.csv'.\
-                            format(date_p, full_time_p)
-            },
-            'flir2tif': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': 'flirIrCamera - {}__{}.(png|tif)'.\
-                            format(date_p, full_time_p)
-            },
-            'ps2_png': {
-            },
-            'bin2csv': {
-            },
-            'EnvironmentLogger': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{filename}',
-                'pattern': '{}_{}_environmentlogger.nc'.\
-                           format(date_p, time_p)
-            },
-            'soil_removal_vnir': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': 'VNIR_lv1_{}__{}_{}'.format(date_p, 
-                           full_time_p, 'uamac_soilremovalmask.nc')
-            },
-            'soil_removal_swir': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': ''
-            },
-            'scanner3DTop_mergedlas': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': 'scanner3DTop_(lv1_)?{}__{}.las'.\
-                           format(date_p, full_time_p,
-                           '(_uamac_merged | MergedPointCloud)')
-            },
-            'scanner3DTop_plant_height': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': ('scanner3DTop - {}__{} {}.npy'.\
-                            format(date_p, full_time_p,
-                              '(highest|historgram)'))
-            },
-            'scanner3DTop_heightmap': {
-                'template': '{TERRAREF_BASE}/{station}/{level}/'
-                            '{sensor}/{date}/{time}/{filename}',
-                'pattern': ('scanner3DTop_lv1_{}__{}_{}.bmp'.\
-                            format(date_p, full_time_p,
-                            'uamac_heightmap(_mask)?'))
-            }
-        },
-        'raw_data': {
-            'stereoTop': {
-                "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e",
-            },
-            'flirIrCamera': {
-                "fixed_metadata_datasetid": "5873a7184f0cad7d8131994a",
-            },
-            "co2Sensor": {
-                "fixed_metadata_datasetid": "5873a9924f0cad7d8131b648"
-            },
-            "cropCircle": {
-                "fixed_metadata_datasetid": "5873a7ed4f0cad7d8131a2e7"
-            },
-            "EnvironmentLogger": {
-                "fixed_metadata_datasetid": "TBD"
-            },
-            "irrigation": {
-                "fixed_metadata_datasetid": "TBD"
-            },
-            "lightning": {
-                "fixed_metadata_datasetid": "TBD"
-            },
-            "ndviSensor": {
-                "fixed_metadata_datasetid": "5873a8f64f0cad7d8131af54"
-            },
-            "parSensor": {
-                "fixed_metadata_datasetid": "5873a8ce4f0cad7d8131ad86"
-            },
-            "priSensor": {
-                "fixed_metadata_datasetid": "5873a9174f0cad7d8131b09a"
-            },            
-            "ps2Top": {
-                "fixed_metadata_datasetid": "5873a84b4f0cad7d8131a73d"
-            },
-            "scanner3DTop": {
-                "fixed_metadata_datasetid": "5873a7444f0cad7d81319b2b"
-            },
-            "stereoTop": {
-                "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e"
-            },
-            "SWIR": {
-                "fixed_metadata_datasetid": "5873a79e4f0cad7d81319f5f"
-            },
-            "VNIR": {
-                "fixed_metadata_datasetid": "5873a7bb4f0cad7d8131a0b7"
-            },
-            "weather": {
-                "fixed_metadata_datasetid": "TBD"
-            },
-        }
-    }
 
+            'EnvironmentLogger': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{filename}',
+                'pattern': '{timestamp}_environment_logger.json'
+            },
+        },
+
+        'Level_1': {
+
+            'rgb_fullfield': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{filename}',
+                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
+            },
+
+            'flirIrCamera': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
+            },
+
+            'stereoTop_geotiff': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
+            },
+
+            'stereoTop_canopyCover': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
+            },
+
+            'texture_analysis': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.csv',
+            },
+
+            'flir2tif': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
+            },
+
+            # {date}_{time}_environmentlogger.nc
+            'EnvironmentLogger': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{filename}',
+                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.nc',
+            },
+
+            'soil_removal_vnir': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': 'VNIR_{level}_{station}_{timestamp}{opts}.nc'
+            },
+
+            'soil_removal_swir': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': 'SWIR_{level}_{station}_{timestamp}{opts}.nc'
+            },
+
+            'scanner3DTop_mergedlas': {
+                'template': '{base}/{station}/{level}/'
+                            'scanner3DTop/{date}/{time}/{filename}',
+                'pattern': 'scanner3DTop_{level}_{station}_{timestamp}'
+                           '_merged{opts}.las'
+            },
+
+            'scanner3DTop_plant_height': {
+                'template': '{base}/{station}/{level}/'
+                            'scanner3DTop/{date}/{time}/{filename}',
+                'pattern': 'scanner3DTop_{level}_{station}_{timestamp}'
+                           '_height{opts}.npy'
+            },
+
+            'scanner3DTop_heightmap': {
+                'template': '{base}/{station}/{level}/'
+                            '{sensor}/{date}/{time}/{filename}',
+                'pattern': 'scanner3DTop_{level}_{station}_{timestamp}'
+                           '_heightmap{opts}.bmp'
+            },
+        },
+    },
 }
+
+
+def add_arguments(parser):
+
+    parser.add_argument('--terraref_base', type=str,
+                        default=os.environ.get('TERRAREF_BASE',
+                        '/projects/arpae/terraref/sites'),
+                        help='Terraref base path')
+
+    parser.add_argument('--terraref_site', type=str,
+                        default=os.environ.get('TERRAREF_SITE',
+                        'ua-mac'), help='station name')
+
+    parser.add_argument('--terraref_level', type=str,
+                        default='Level_1')
+
+    parser.add_argument('--terraref_sensor', type=str,
+                        default='fullfield')
 
 
 def exact_p(pattern):
@@ -237,143 +175,9 @@ def exact_p(pattern):
     return '^{}$'.format(pattern)
 
 
-def get_sensor_path(station, level, sensor, date='', time='',
-                    filename=''):
-    """Get the appropritate path for writing sensor data
+def extract_date(timestamp):
 
-    Args:
-      station (str): abbreviated name of the site
-      level (str): data level (raw_data | Level_1 | Level_2)
-      sensor (str): sensor name, may be a product name for Level_1
-      date (YYYY-MM-DD str): optional date field
-      time (datetime str): optional time field
-      filename (str): option filename, must match sensor pattern
-      
-    Returns:
-      (str) full path
-
-    Notes:
-      When no filename is given, get_sensor_path returns the desired
-      path with pre-defined, well-known filename. If filename is not
-      given and no pre-defined filename exists, then a RuntimeError
-      is raised.
-
-      If a filename is supplied, it must patch a pre-defined pattern.
-      A RuntimeError is raised if the filename does not match the 
-      pattern.
-    """
-
-    if date and re.match(exact_p(date_p), date)==None:
-        raise RuntimeError('The date given is in the wrong format')
-
-    if time and re.match(exact_p(full_date_p), time)==None:
-        raise RuntimeError('The time given is in the wrong format')
-
-    try:
-        s = STATIONS[station][level][sensor]
-    except KeyError:
-        raise RuntimeError('The station, level or sensor given does'
-                           'not exist')
-
-    if filename:
-        result = re.match(exact_p(s['pattern']), filename)
-        if result==None:
-            raise RuntimeError('The filename given does not match '
-                               'the correct pattern')
-    else:
-        try:
-            filename = s['filename']
-        except KeyError:
-            raise RuntimeError('No default filename found, you need '
-                               'to specify a filename')
-
-
-    path = s['template'].format(TERRAREF_BASE=TERRAREF_BASE,
-                                station=station, level=level,
-                                sensor=sensor, date=date, time=time,
-                                filename=filename)
-    return path
-
-
-def create_sensor_path(path):
-    """
-    Check if the path exists. If it exists, then do nothing.
-    If not, then create all the missing subdirectories.
-    """
-    if not os.path.exists(os.path.dirname(path)):
-        os.makedirs(os.path.dirname(path))
-
-
-def get_sensors(station):
-    """ Get all sensors for a given station."""
-    return STATIONS[station]['sensors'].keys()
-
-
-def get_sites():
-    """ Get all sites (stations) listed."""
-    return STATIONS.keys()
-
-
-def get_sitename(station, date, range_=None, column=None):
-    """ Returns a full sitename for the plot (or fullfield image)
-    corresponding to the given station, date, range and column.
-
-    Args:
-      station (str): the name of the station
-      date (str): the date when the image was taken
-      range_ (str): the vertical index of the plot in the fullfield
-      column (str): the horizontal index of the plot in the fullfield
-
-    Returns:
-      (str): the full sitename for the plot (or the fullfield image)
-    """
-
-    site = STATIONS[station]['sitename']
-    season = int(date[:4])-2013
-    sitename = '{} Season {} Range {} Column {}'.\
-              format(site, season, range_, column)
-    return sitename
-
-
-def check_site(station):
-    """ Checks for valid station given the station name, and return its
-    path in the file system.
-    """
-
-    if not os.path.exists(TERRAREF_BASE):
-        raise InvalidUsage('Could not find data, try setting TERRAREF_BASE environmental variable')
-
-    sitepath = os.path.join(TERRAREF_BASE, station)
-    if not os.path.exists(sitepath):
-        raise InvalidUsage('unknown site', payload={'site': station})
-
-    return sitepath
-
-
-def check_sensor(station, sensor, date=None):
-    """ Checks for valid sensor with optional date, and return its path
-    in the file system.
-    """
-
-    sitepath = check_site(station)
-
-    sensorpath = os.path.join(sitepath, 'Level_1', sensor)
-    if not os.path.exists(sensorpath):
-        raise InvalidUsage('unknown sensor',
-                           payload={'site': station, 'sensor': sensor})
-
-    if not date:
-        return sensorpath
-
-    datepath = os.path.join(sensorpath, date)
-    print("datepath = {}".format(datepath))
-    if not os.path.exists(datepath):
-        raise InvalidUsage('sensor data not available for given date',
-                           payload={'site': station, 'sensor': sensor,
-                                    'date': date})
-
-    return datepath
-
+    return timestamp.split('__')[0]
 
 def get_attachment_name(site, sensor, date, product):
     """ Encodes site, sensor, and date to create a unique attachment name.
@@ -389,50 +193,193 @@ def plot_attachment_name(sitename, sensor, date, product):
 
     root, ext = os.path.splitext(product)
     return "{}-{}-{}.{}".format(sitename, sensor, date, ext) 
-    
-def get_fixed_datasetid_for_sensor(station, sensor):
-    """ Returns the Clowder dataset ID for the fixed sensor information
+
+
+class Sensors():
+    """Simple class used to save components of the file system path
+    where sensor data will be stored.
     """
-    return STATIONS[station]["raw_data"][sensor]["fixed_metadata_datasetid"]    
+
+    def __init__(self, base, station, level, sensor):
+        """Initialize basic path elements from env and cmdline."""
+
+        self.base = base
+        self.station = station
+        self.level = level
+        self.sensor = sensor
 
 
-if __name__ == '__main__':
-    try:
-        print get_sensor_path('ua-mac', 'Level_1', 'rgb_fullfield', '2017-04-27')
-    except Exception as e:
-        print(e)
+    def get_sensor_path(self, timestamp, sensor='', filename='',
+                        opts=None, ext=''):
+        """Get the appropritate path for writing sensor data
+    
+        Args:
+          time (datetime str): timestamp string
+          filename (str): option filename, must match sensor pattern
+          
+        Returns:
+          (str) full path to file
+    
+        Notes:
+          When no filename is given, get_sensor_path returns the desired
+          path with pre-defined, well-known filename. If filename is not
+          given and no pre-defined filename exists, then a RuntimeError
+          is raised.
+    
+          If a filename is supplied, it must match a pre-defined pattern.
+          A RuntimeError is raised if the filename does not match the 
+          pattern.
+        """
 
-    try:
-        print get_sensor_path('ua-mac', 'Level_1', 'rgb_fullfield', '20127')
-    except Exception as e:
-        print(e)
+        if re.match(exact_p(full_date_p), timestamp)==None:
+            raise RuntimeError('Timestamp has the wrong format')
 
-    try:
-        print get_sensor_path('ua-mac', 'Level_1', 'stereoTop_geotiff', '2017-04-27', '2017-04-27__13-48-56-082', 'stereoTop_lv1_2016-04-29__13-53-42-743_uamac_left.jpg')
-    except Exception as e:
-        print(e)
+        # override class sensor
+        if not sensor:
+            sensor = self.sensor
 
-    try:
-        print get_sensor_path('ua-mac', 'Level_1', 'stereoTop_geotiff', '2017-04-27', '13-48-56-082', 'stereoTop_lv1_2016-04-29__13-53-42-743_uamac_left.jpg')
-    except Exception as e:
-        print(e)
+        # create opt string
+        if opts:
+            opts = '_'.join(['']+opts)
+        else:
+           opts = ''
+    
+        # split timestamp into date and hour-minute-second components
+        date, hms = timestamp.split('__')
 
-    try:
-        print get_sensor_path('ua', 'Level_1', 'flirIrCamera', '2017-04-27', '2017-04-27__23-12-13-999', 'uamac_soilremovalmask.nc')
-    except Exception as e:
-        print(e)
+        try:
+            s = STATIONS[self.site][self.level][sensor]
+                
+        except KeyError:
+            raise RuntimeError('The station, level or sensor given does'
+                               ' not exist')
 
-    try:
-        print get_sensor_path('ua-mac', 'Level_1', 'flirIrCamera', '2017-04-27', '2017-04-27__23-12-13-999', 'uamac_soilremovalmask.nc')
-    except Exception as e:
-        print(e)
+        # TODO pattern should be completed with regex string using format
+        if filename:
+            result = re.match(exact_p(s['pattern']), filename)
+            #if result==None:
+            #    raise RuntimeError('The filename given does not match '
+            #                       'the correct pattern')
 
-    try:
-        print get_sensor_path('ua-mac', 'Level_1', 'flirIrCamera', '2017-04-27', '2017-04-27__23-12-13-999', '')
-    except Exception as e:
-        print(e)
+        # TODO check that all fields from patterns are available
+        # TODO write the _level_name function (maps Level_1 to lv1, etc)
+        else:
+            filename = s['pattern'].format(station=self.station, 
+                    level=self._level_names(self.level), sensor=sensor,
+                    timestamp=timstamp, date=date, time=hms,
+                    opts=opts)
+                                           
+        # TODO split extension with os.path function than do 
+        # a string match and replace
+        if ext:
+            filename = filename.split('.')[0] + ext
 
-    try:
-        print get_sensor_path('ua-mac', 'Level_1', 'scanner3DTop_heightmap', '2017-04-27', '2017-04-27__15-16-17-888', 'scanner3DTop_lv1_2017-06-06__17-14-31-218_uamac_heightmap_mask.bmp')
-    except Exception as e:
-        print(e)
+        path = s['template'].format(base=self.base, station=self.station,
+                                    level=self.level, sensor=self.sensor,
+                                    timestamp=timstamp, date=date, time=hms,
+                                    filename=filename)
+        return path
+    
+
+    def get_sensor_path_by_dataset(self, datasetname, sensor='',
+                                   ext='', opts=None, hms=None):
+        """Get the appropritate path for writing sensor data
+    
+        Args:
+          station (str): abbreviated name of the site
+          level (str): data level (raw_data | Level_1 | Level_2)
+          datasetname (sensor - date__timestamp str): 
+              e.g. VNIR - 2017-06-28__23-48-28-435
+          sensor (str): sensor name, may be a product name for Level_1
+          opts (list of strs): any suffixes to apply to generated filename
+          hms (str): allows one to add/override a timestamp 
+          if not included in datasetname (e.g. EnvironmentLogger)
+    
+        Returns:
+          (str) full path
+        """
+    
+        # Split dataset into sensorname and timestamp portions
+        if datasetname.find(" - ") > -1:
+            sensorname, time = datasetname.split(" - ")
+        else:
+            sensorname = datasetname
+            time = "2017"
+
+        # Get date portion of timestamp if there is one; if not,
+        # assume whole thing is just the date
+        if time.find("__") > -1:
+            date = time.split("__")[0]
+        else:
+            date = time
+            time = ""
+
+        # Override timestamp if necessary
+        if hms:
+            time = date + "__" + hms
+
+        # Override dataset sensor name with provided name if given 
+        # (e.g. use timestamp of raw while getting Level_1 output)
+        if sensor == "":
+            sensor = sensorname
+    
+        return self.get_sensor_path(time, sensor=sensor, opts=opts, ext=ext)
+
+
+    def create_sensor_path(self, path):
+        """Create path if does not exist."""
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+    
+    
+    def get_sensors(self, station):
+        """Get all sensors for a given station."""
+        return STATIONS[self.station]['sensors'].keys()
+    
+    
+    def get_sites(self):
+        """Get all sites (stations) listed."""
+        return STATIONS.keys()
+    
+    
+    def check_site(self, station):
+        """ Checks for valid station given the station name, and return its
+        path in the file system.
+        """
+    
+        if not os.path.exists(self.base):
+            raise InvalidUsage('Could not find data, try setting '
+                               'TERRAREF_BASE environmental variable')
+    
+        sitepath = os.path.join(self.base, self.station)
+        if not os.path.exists(sitepath):
+            raise InvalidUsage('unknown site', payload={'site': station})
+    
+        return sitepath
+    
+    
+    def check_sensor(station, sensor, date=None):
+        """ Checks for valid sensor with optional date, and return its path
+        in the file system.
+        """
+    
+        sitepath = check_site(station)
+    
+        sensorpath = os.path.join(sitepath, 'Level_1', sensor)
+        if not os.path.exists(sensorpath):
+            raise InvalidUsage('unknown sensor',
+                               payload={'site': station, 'sensor': sensor})
+    
+        if not date:
+            return sensorpath
+    
+        datepath = os.path.join(sensorpath, date)
+        print("datepath = {}".format(datepath))
+        if not os.path.exists(datepath):
+            raise InvalidUsage('sensor data not available for given date',
+                               payload={'site': station, 'sensor': sensor,
+                                        'date': date})
+    
+        return datepath
+    
+    


### PR DESCRIPTION
More improvements for creating and locating sensor data on the file system. An internal dictionary provides two string templates for generating a filename and full path. Many of the path components (station, level, sensor, etc) can be specified using environmental variables and overridden with command line arguments to simplify starting extractor containers.

Includes a slight re-working of Max's get_sensor_path_by_dataset that extracts sensor and timestamp from the Clowder dataset name.

Actual sensor names still need to be reviewed!