### PR TITLE
Remove the use of the level parameter and changed create_sensor_path.

### DIFF
--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -35,7 +35,8 @@ def get_bety_key():
         keyfile = open(keyfile_path, "r")
         return keyfile.readline().strip()
 
-    raise RuntimeError("BETYDB_URL not found. Set environmental variable "
+    else:
+        raise RuntimeError("BETYDB_URL not found. Set environmental variable "
                        "or create $HOME/.betykey.")
 
 
@@ -164,8 +165,14 @@ def get_site_boundaries(**kwargs):
     return bboxes
 
 
-def submit_traits(csv, filetype='csv', betykey=get_bety_key(), betyurl=get_bety_api("traits")):
+def submit_traits(csv, filetype='csv', betykey='', betyurl=''):
     """ Submit traits file to BETY; can be CSV, JSON or XML."""
+
+    # set defaults if necessary
+    if not betykey:
+        betykey = get_bety_key()
+    if not betyurl:
+        betyurl = get_bety_api('traits')
 
     request_payload = { 'key':betykey }
 

--- a/terrautils/sensors.py
+++ b/terrautils/sensors.py
@@ -23,232 +23,197 @@ time_p = '([0-1]\d|2[0-3])-([0-5]\d)-([0-5]\d)'
 full_time_p = '([0-1]\d|2[0-3])-([0-5]\d)-([0-5]\d)-(\d{3})'
 # 2017-06-28__23-48-28-435
 full_date_p = '{}__{}'.format(date_p, full_time_p)
-filename_level_p = '(raw|lv1|lv2)'
-path_level_p = '(raw_data|Level_1|Level_2)'
 
 
 STATIONS = {
     'danforth': {
-        'title': 'Danforth Plant Science Center '
-                    'Bellweather Phenotyping Facility',
-        'raw_data': {
-            'ddpscIndoorSuite': {
-                'template': '{base}/{station}/{level}/'
+        'ddpscIndoorSuite': {
+            'template': '{base}/{station}/raw_data/'
                             '{sensor}/{snapshotID}/{filename}',
-                'pattern': 'avg_traits.csv'
-            }
+            'pattern': 'avg_traits.csv'
         }
     },
 
     'ksu': {
-        'title': 'Ashland Bottoms KSU Field Site',
-        'raw_data': {
+        'dsm': {
+            'template': '{base}/{station}/Level_1/{sensor}/{filename}',
+            'pattern': '{time}_DSM_16ASH-TERRA.tif'
         },
-
-        'Level_1': {
-            'dsm': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{filename}',
-                'pattern': '{time}_DSM_16ASH-TERRA.tif'
-            },
-            'rededge': {
-                'template': '{base}/{station}/{Level_1}/'
-                            '{sensor}/{filename}',
-                'pattern': '{time}_BGREN_16ASH-TERRA'
-            }
-        },
-        'Level_2': {
+        'rededge': {
+            'template': '{base}/{station}/Level_1/{sensor}/{filename}',
+            'pattern': '{time}_BGREN_16ASH-TERRA'
         }
     },
 
     'ua-mac': {
-        'title': 'MAC Field Scanner',
-        'raw_data': {
-            'co2Sensor': {
-                "fixed_metadata_datasetid": "5873a9924f0cad7d8131b648",
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': '([0-9a-f]){8}-([0-9a-f]){4}-([0-9'
-                           'a-f]){4}-([0-9a-f]){4}-([0-9a-f])'
-                           '{12}_(metadata.json|rawData0000.bin)'
-            },
-            
-            'stereoTop': {
-                "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e"
-            },
-            
-            'flirIrCamera': {
-                "fixed_metadata_datasetid": "5873a7184f0cad7d8131994a"
-            },
-            
-            "cropCircle": {
-                "fixed_metadata_datasetid": "5873a7ed4f0cad7d8131a2e7"
-            },
-            
-            "irrigation": {
-                "fixed_metadata_datasetid": "TBD"
-            },
-            
-            'EnvironmentLogger': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{filename}',
-                'pattern': '{timestamp}_environment_logger.json',
-                'fixed_metadata_datasetid': 'TBD'
-            },
-            
-            "lightning": {
-                "fixed_metadata_datasetid": "TBD"
-            },
-            
-            "ndviSensor": {
-                "fixed_metadata_datasetid": "5873a8f64f0cad7d8131af54"
-            },
-            
-            "parSensor": {
-                "fixed_metadata_datasetid": "5873a8ce4f0cad7d8131ad86"
-            },
-            
-            "priSensor": {
-                "fixed_metadata_datasetid": "5873a9174f0cad7d8131b09a"
-            },
-            
-            "ps2Top": {
-                "fixed_metadata_datasetid": "5873a84b4f0cad7d8131a73d"
-            },
-            
-            "scanner3DTop": {
-                "fixed_metadata_datasetid": "5873a7444f0cad7d81319b2b"
-            },
-            
-            "stereoTop": {
-                "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e"
-            },
-            
-            "SWIR": {
-                "fixed_metadata_datasetid": "5873a79e4f0cad7d81319f5f"
-            },
-            
-            "VNIR": {
-                "fixed_metadata_datasetid": "5873a7bb4f0cad7d8131a0b7"
-            },
-            
-            "weather": {
-                  "fixed_metadata_datasetid": "TBD"
-            }
+        'co2Sensor': {
+            "fixed_metadata_datasetid": "5873a9924f0cad7d8131b648",
+            'template': '{base}/{station}/raw_data/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': '([0-9a-f]){8}-([0-9a-f]){4}-([0-9'
+                       'a-f]){4}-([0-9a-f]){4}-([0-9a-f])'
+                       '{12}_(metadata.json|rawData0000.bin)'
+        },
+        
+        'stereoTop': {
+            "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e"
+        },
+        
+        'flirIrCamera': {
+            "fixed_metadata_datasetid": "5873a7184f0cad7d8131994a"
+        },
+        
+        "cropCircle": {
+            "fixed_metadata_datasetid": "5873a7ed4f0cad7d8131a2e7"
+        },
+        
+        "irrigation": {
+            "fixed_metadata_datasetid": "TBD"
+        },
+        
+        'EnvironmentLogger': {
+            'template': '{base}/{station}/raw_data/'
+                        '{sensor}/{date}/{filename}',
+            'pattern': '{timestamp}_environment_logger.json',
+            'fixed_metadata_datasetid': 'TBD'
+        },
+        
+        "lightning": {
+            "fixed_metadata_datasetid": "TBD"
+        },
+        
+        "ndviSensor": {
+            "fixed_metadata_datasetid": "5873a8f64f0cad7d8131af54"
+        },
+        
+        "parSensor": {
+            "fixed_metadata_datasetid": "5873a8ce4f0cad7d8131ad86"
+        },
+        
+        "priSensor": {
+            "fixed_metadata_datasetid": "5873a9174f0cad7d8131b09a"
+        },
+        
+        "ps2Top": {
+            "fixed_metadata_datasetid": "5873a84b4f0cad7d8131a73d"
+        },
+        
+        "scanner3DTop": {
+            "fixed_metadata_datasetid": "5873a7444f0cad7d81319b2b"
+        },
+        
+        "stereoTop": {
+            "fixed_metadata_datasetid": "5873a8ae4f0cad7d8131ac0e"
+        },
+        
+        "SWIR": {
+            "fixed_metadata_datasetid": "5873a79e4f0cad7d81319f5f"
+        },
+        
+        "VNIR": {
+            "fixed_metadata_datasetid": "5873a7bb4f0cad7d8131a0b7"
+        },
+        
+        "weather": {
+              "fixed_metadata_datasetid": "TBD"
         },
 
-        'Level_1': {
+        'rgb_fullfield': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{date}{opts}.tif',
+        },
 
-            'fullfield': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{filename}',
-                'pattern': '{sensor}_{level}_{station}_{date}{opts}.tif',
-            },
+        'flirIrCamera': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{timestamp}{opts}.tif',
+        },
 
-            'flirIrCamera': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
-            },
+        'stereoTop_geotiff': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{timestamp}{opts}.tif',
+        },
 
-            'stereoTop_geotiff': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
-            },
+        'stereoTop_canopyCover': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{timestamp}{opts}.tif',
+        },
 
-            'stereoTop_canopyCover': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
-            },
+        'texture_analysis': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{timestamp}{opts}.csv',
+        },
 
-            'texture_analysis': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.csv',
-            },
+        'flir2tif': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{timestamp}{opts}.tif',
+        },
 
-            'flir2tif': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.tif',
-            },
+        'EnvironmentLogger': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{timestamp}{opts}.nc',
+        },
 
-            'EnvironmentLogger': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{filename}',
-                'pattern': '{sensor}_{level}_{station}_{timestamp}{opts}.nc',
-            },
+        'soil_removal_vnir': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': 'VNIR_lv1_{station}_{timestamp}{opts}.nc'
+        },
 
-            'soil_removal_vnir': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': 'VNIR_{level}_{station}_{timestamp}{opts}.nc'
-            },
-            'soil_removal_swir': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': 'SWIR_{level}_{station}_{timestamp}{opts}.nc'
-            },
+        'soil_removal_swir': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': 'SWIR_lv1_{station}_{timestamp}{opts}.nc'
+        },
 
-            'scanner3DTop_mergedlas': {
-                'template': '{base}/{station}/{level}/'
-                            'scanner3DTop/{date}/{timestamp}/{filename}',
-                'pattern': 'scanner3DTop_{level}_{station}_{timestamp}'
-                           '_merged{opts}.las'
-            },
+        'scanner3DTop_mergedlas': {
+            'template': '{base}/{station}/Level_1/'
+                        'scanner3DTop/{date}/{time}/{filename}',
+            'pattern': 'scanner3DTop_lv1_{station}_{timestamp}'
+                       '_merged{opts}.las'
+        },
 
-            'scanner3DTop_plant_height': {
-                'template': '{base}/{station}/{level}/'
-                            'scanner3DTop/{date}/{timestamp}/{filename}',
-                'pattern': 'scanner3DTop_{level}_{station}_{timestamp}'
-                           '_height{opts}.npy'
-            },
+        'scanner3DTop_plant_height': {
+            'template': '{base}/{station}/Level_1/'
+                        'scanner3DTop/{date}/{time}/{filename}',
+            'pattern': 'scanner3DTop_lv1_{station}_{timestamp}'
+                       '_height{opts}.npy'
+        },
 
-            'scanner3DTop_heightmap': {
-                'template': '{base}/{station}/{level}/'
-                            '{sensor}/{date}/{timestamp}/{filename}',
-                'pattern': 'scanner3DTop_{level}_{station}_{timestamp}'
-                           '_heightmap{opts}.bmp'
-            },
+        'scanner3DTop_heightmap': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{time}/{filename}',
+            'pattern': 'scanner3DTop_lv1_{station}_{timestamp}'
+                       '_heightmap{opts}.bmp'
         },
     },
 }
 
 
-def _level_names(self, level):
-    """Convert level path name to level file name."""
-
-    LV_CONV = {
-        'raw_data': 'raw',
-        'Level_1': 'lv1',
-        'Level_2': 'lv2'
-    }
-
-    return LV_CONV[level]
-
-
 def add_arguments(parser):
+
     if os.path.exists('/projects/arpae/terraref/sites'):
         TERRAREF_BASE = '/projects/arpae/terraref/sites'
     else:
         TERRAREF_BASE = '/home/extractor/sites'
 
     parser.add_argument('--terraref_base', type=str,
-                        default=os.getenv('TERRAREF_BASE', TERRAREF_BASE),
-                        help='Terraref base path')
+            default=os.environ.get('TERRAREF_BASE', TERRAREF_BASE),
+            help='path to the sites directory on local host')
 
     parser.add_argument('--terraref_site', type=str,
-                        default=os.getenv('TERRAREF_SITE', 'ua-mac'),
-                        help='station name')
-
-    # TODO: Hide this and use dict to fill in this piece based on product/sensor
-    parser.add_argument('--terraref_level', type=str,
-                        default=os.getenv('TERRAREF_LEVEL', 'Level_1'))
+            default=os.environ.get('TERRAREF_SITE', 'ua-mac'),
+            help='site name (default=TERRAREF_SITE | ua-mac)')
 
     parser.add_argument('--terraref_sensor', type=str,
-                        default=os.getenv('TERRAREF_SENSOR', ''))
+            default=os.environ.get('TERRAREF_SENSOR', ''),
+            help='sensor name (default=None)')
 
 
 def exact_p(pattern):
@@ -261,33 +226,47 @@ class Sensors():
     where sensor data will be stored.
     """
 
-    def __init__(self, base, station, level, sensor):
+    def __init__(self, base, station, sensor='', stations=STATIONS):
         """Initialize basic path elements from env and cmdline."""
 
+        self.stations = stations
         self.base = base.rstrip('/')
 
-        if station in STATIONS.keys():
+        if station in self.stations.keys():
             self.station = station
         else:
             raise AttributeError('unknown station name "{}"'.format(station))
 
-        if level in STATIONS[station].keys():
-            self.level = level
-        else: 
-            raise AttributeError('unknown data level "{}"'.format(level))
+        self._sensor = sensor
 
-        if sensor in STATIONS[station][level].keys():
-            self.sensor = sensor
+
+    @property
+    def sensor(self):
+
+        if self._sensor:
+            return self._sensor
         else:
-            raise AttributeError('unknown sensor name "{}"'.format(sensor))
+            raise RuntimeError('sensor not set')
+        
+
+    @sensor.setter
+    def sensor(value):
+        if value in self.stations[self.station].keys():
+            self._sensor = value
+        else:
+            raise AttributeError('unknown sensor name "{}"'.format(value))
 
 
-    def get_sensor_path(self, timestamp, sensor='', filename='', opts=None, ext=''):
-        """Get the appropriate path for writing sensor data
+    def get_sensor_path(self, timestamp, sensor='', filename='',
+                        opts=None, ext=''):
+        """Get the appropritate path for writing sensor data
 
         Args:
-          time (datetime str): timestamp string
-          filename (str): option filename, must match sensor pattern
+          timestamp (datetime str): timestamp string
+          sensor (str): overrides instance sensor variable, optional
+          filename (str): overrides default filename, optional
+          opts (list): list of filename extensions, optional
+          ext (str): overrides the default filename extension, optional
 
         Returns:
           (str) full path to file
@@ -306,57 +285,52 @@ class Sensors():
         # override class sensor
         if not sensor:
             sensor = self.sensor
+        # split timestamp into date and hour-minute-second components
+        if timestamp.find('__') > -1:
+            date, hms = timestamp.split('__')
+        else:
+            raise RuntimeError('sensor {} does not exist'.format(sensor))
+
+        # Get regex patterns for this site/sensor
+        try:
+            s = self.stations[self.station][sensor]
+        except KeyError:
+            raise RuntimeError('sensor {} does not exist'.format(sensor))
+
         # create opt string
         if opts:
             opts = '_'.join(['']+opts)
         else:
             opts = ''
-        # split timestamp into date and hour-minute-second components
-        if timestamp.find('__') > -1:
-            date, hms = timestamp.split('__')
-        else:
-            date = timestamp
-            timestamp, hms = '', ''
 
-        # Get regex patterns for this site/sensor
-        try:
-            s = STATIONS[self.station][self.level][sensor]
-        except KeyError:
-            raise RuntimeError('The site, level or sensor given does not exist')
-
-        # If filename is given when getting path, validate it
+        # pattern should be completed with regex string using format
         if filename:
-            try:
-                pattern = exact_p(s['pattern']).format(sensor='\D*',
-                              level='(raw|lv1|lv2)', station='\D*',
-                              date=date_p, time=full_time_p,
-                              timestamp=full_date_p, opts='\D*')
-            except KeyError:
-                raise RuntimeError('Some fields from the pattern are not available')
+            pattern = exact_p(s['pattern']).format(sensor='\D*',
+                    station='\D*', date=date_p, time=full_time_p,
+                    timestamp=full_date_p, opts='\D*')
 
             result = re.match(pattern, filename)
-            if result==None:
+            if result == None:
                 raise RuntimeError('The filename given does not match the correct pattern')
 
-        # If not given, generate filename from parameters
         else:
             filename = s['pattern'].format(station=self.station,
-                    level=_level_names(self.level), sensor=sensor,
-                    timestamp=timestamp, date=date, time=hms, opts=opts)
-            # Override pattern extension if necessary
-            if ext:
-                if not ext.startswith('.'):
-                    ext = '.' + ext
-                filename = os.path.splitext(filename)[0] + ext
+                    sensor=sensor, timestamp=timestamp, date=date, time=hms,
+                    opts=opts)
 
-        # Return fully formed path with generated/validated filename
-        return s['template'].format(base=self.base, station=self.station,
-                                    level=self.level, sensor=self.sensor,
-                                    timestamp=timestamp, date=date, time=hms,
-                                    filename=filename)
+        # replace default extension in filename
+        if ext:
+            filename = '.'.join([os.path.splitext(filename)[0], 
+                                ext.lstrip('.')])
+
+        path = s['template'].format(base=self.base, station=self.station,
+                                    sensor=self.sensor, timestamp=timestamp,
+                                    date=date, time=hms, filename=filename)
+        return path
 
 
-    def get_sensor_path_by_dataset(self, dsname, sensor='', ext='', opts=None, hms=''):
+    def get_sensor_path_by_dataset(self, dsname, sensor='', ext='', 
+                                   opts=None, hms=''):
         """Get the appropritate path for writing sensor data
 
         Args:
@@ -365,7 +339,7 @@ class Sensors():
           sensor (str): sensor name, may be a product name for Level_1
           opts (list of strs): any suffixes to apply to generated filename
           hms (str): allows one to add/override a timestamp
-          if not included in datasetname (e.g. EnvironmentLogger)
+              if not included in datasetname (e.g. EnvironmentLogger)
 
         Returns:
           (str) full path
@@ -394,31 +368,39 @@ class Sensors():
         return self.get_sensor_path(time, sensor=sensor, opts=opts, ext=ext)
 
 
-    def get_fixed_datasetid_for_sensor(self, site, level, sensor):
-        """ Returns the Clowder dataset ID for the fixed sensor information
-        """
+    def get_fixed_datasetid_for_sensor(site='', sensor=''):
+        """Return the Clowder dataset ID for the fixed sensor information"""
 
         if not site:
             site = self.station
-        if not level:
-            level = self.level
         if not sensor:
             sensor = self.sensor
 
-        return STATIONS[site][level][sensor]['fixed_metadata_datasetid']
+        return self.stations[site][sensor]['fixed_metadata_datasetid']
 
 
-    def create_sensor_path(self, path):
-        """Create path if does not exist."""
+    def create_sensor_path(self, timestamp, sensor='', filename='',
+                        opts=None, ext=''):
+        """Return the full path for the sensor data
+        
+        Note: this function is similar to get_sensor_path and takes
+        all the same arguments but has a side-effect of creating
+        any missing directories in the path.
+        """
 
-        if not os.path.exists(os.path.dirname(path)):
-            os.makedirs(os.path.dirname(path))
+        path = self.get_sensor_path(timestamp, sensor, filename,
+                                        opts, ext)
+        dirs = os.path.dirname(path) 
+        if not os.path.exists(dirs):
+            os.makedirs(dirs)
+
+        return path
 
 
     def get_sites(self):
         """Get all sites (stations) listed."""
 
-        return STATIONS.keys()
+        return self.stations.keys()
 
 
     def get_season(self, date):
@@ -437,48 +419,12 @@ class Sensors():
                 return exp['name'][:exp['name'].find(':')]
 
 
-    def get_sensors(self):
+    def get_sensors(self, station=''):
         """Get all sensors for a given station."""
 
-        return STATIONS[self.station][self.level].keys()
+        # TODO: allow the KeyError on bad station name?
+        if station:
+            return self.stations[station].keys()
+        else:
+            return self.stations[self.station].keys()
 
-
-    def check_site(self, station):
-        """ Checks for valid station given the station name, and return its
-        path in the file system.
-        """
-
-        if not os.path.exists(self.base):
-            raise InvalidUsage('Could not find data, try setting '
-                               'TERRAREF_BASE environmental variable')
-
-        sitepath = os.path.join(self.base, self.station)
-        if not os.path.exists(sitepath):
-            raise InvalidUsage('unknown site', payload={'site': station})
-
-        return sitepath
-
-
-    def check_sensor(self, station, sensor, date=None):
-        """ Checks for valid sensor with optional date, and return its path
-        in the file system.
-        """
-
-        sitepath = self.check_site(station)
-
-        sensorpath = os.path.join(sitepath, 'Level_1', sensor)
-        if not os.path.exists(sensorpath):
-            raise InvalidUsage('unknown sensor',
-                               payload={'site': station, 'sensor': sensor})
-
-        if not date:
-            return sensorpath
-
-        datepath = os.path.join(sensorpath, date)
-        print("datepath = {}".format(datepath))
-        if not os.path.exists(datepath):
-            raise InvalidUsage('sensor data not available for given date',
-                               payload={'site': station, 'sensor': sensor,
-                                        'date': date})
-
-        return datepath

--- a/tests/sensors_test.py
+++ b/tests/sensors_test.py
@@ -4,56 +4,78 @@ from terrautils.sensors import Sensors
 
 TERRAREF_BASE='/projects/arpae/terraref/sites'
 TIMESTAMP = '2017-04-27__15-10-48-141'
+STATIONS = { 
 
-@pytest.mark.parametrize("station, level, sensor", [
-    ('ua-mac', 'Level_1', 'rgb_fullfield'),
-    ('ua-mac', 'Level_1', 'rgb_fullfield'),
+    'station1': {
+        'raw_sensor1': {
+            'template': '{base}/{station}/raw_data/'
+                        '{sensor}/{date}/{filename}',
+            'pattern': '{sensor}_raw_{station}_{date}{opts}.alt',
+        },
+
+        'lv1_sensor1': {
+            'template': '{base}/{station}/Level_1/'
+                        '{sensor}/{date}/{filename}',
+            'pattern': '{sensor}_lv1_{station}_{date}{opts}.alt',
+        },
+
+        'lv2_sensor1': {
+            'template': '{base}/{station}/Level_2/'
+                        '{sensor}/{date}/{filename}',
+            'pattern': '{sensor}_lv2_{station}_{date}{opts}.alt',
+        },
+    },
+}
+
+def test_class_create():
+    s = Sensors(TERRAREF_BASE, 'station1', 'lv1_sensor1', stations=STATIONS)
+    assert isinstance(s, Sensors)
+
+@pytest.mark.parametrize("station, sensor, expected", [
+    ('fail', 'lv1_sensor1', 'unknown station'),
+    ('station1', 'fail', 'unknown sensor'),
 ])
-def test_class_create(station, level, sensor):
-    Sensors(TERRAREF_BASE, station, level, sensor)
-
-
-@pytest.mark.parametrize("station, level, sensor, expected", [
-    ('mac', 'Level_1', 'rgb_fullfield', 'unknown station'),
-    ('ua-mac', 'Level_N', 'rgb_fullfield', 'unknown level'),
-    ('ua-mac', 'Level_1', 'rgb', 'unknown sensor'),
-])
-def test_class_create_fail(station, level, sensor, expected):
+def test_class_create_fail(station, sensor, expected):
     with pytest.raises(AttributeError) as e:
-        Sensors(TERRAREF_BASE, station, level, sensor)
+        Sensors(TERRAREF_BASE, station, sensor, stations=STATIONS)
         assert expected in str(e)
     
-@pytest.mark.parametrize("station, level, sensor, timestamp, expected", [
-    ('ua-mac', 'Level_1', 'rgb_fullfield', '2017-04-27__15-10-48-141',
+# fixture used for the following tests
+@pytest.fixture
+def sensor():
+    """return standard Sensor instance used for most tests."""
+
+    return Sensors(TERRAREF_BASE, 'station1', 'lv1_sensor1',
+                   stations=STATIONS)
+
+def test_bad_timestamp(sensor):
+    with pytest.raises(RuntimeError) as e:
+        sensor.get_sensor_path('2017-04-')
+
+def test_opts_usage(sensor):
+    opts=['opt1']
+    path = sensor.get_sensor_path(TIMESTAMP, opts=opts)
+    assert path.endswith('_opt1.alt')
+
+def test_multiopts_usage(sensor):
+    opts=['opt1', 'opt2', 'opt3']
+    path = sensor.get_sensor_path(TIMESTAMP, opts=opts)
+    assert path.endswith('_opt1_opt2_opt3.alt')
+
+def test_alt_extension(sensor):
+    path = sensor.get_sensor_path(TIMESTAMP, ext='new')
+    assert path.endswith('.new')
+     
+# TODO: implement tests for all known sensors? Seems excessive.
+@pytest.mark.parametrize("station, sensor, timestamp, expected", [
+    ('ua-mac', 'rgb_fullfield', '2017-04-27__15-10-48-141',
      'ua-mac/Level_1/rgb_fullfield/2017-04-27/rgb_fullfield_lv1_ua-mac_2017-04-27.tif'),
-    ('ua-mac', 'Level_1', 'rgb_fullfield', '2017-04-27__15-10-48-141',
+    ('ua-mac', 'rgb_fullfield', '2017-04-27__15-10-48-141',
      'ua-mac/Level_1/rgb_fullfield/2017-04-27/rgb_fullfield_lv1_ua-mac_2017-04-27.tif'),
 ])
-def test_paths(station, level, sensor, timestamp, expected):
-    s = Sensors(TERRAREF_BASE, station, level, sensor)
+def test_paths(station, sensor, timestamp, expected):
+    s = Sensors(TERRAREF_BASE, station, sensor)
     path = s.get_sensor_path(timestamp)
     results = os.path.join(TERRAREF_BASE, expected)
     assert path == results
 
-def test_bad_timestamp():
-    s = Sensors(TERRAREF_BASE, 'ua-mac', 'Level_1', 'rgb_fullfield')
-    with pytest.raises(RuntimeError) as e:
-        s.get_sensor_path('2017-04-')
-
-def test_opts_usage():
-    s = Sensors(TERRAREF_BASE, 'ua-mac', 'Level_1', 'rgb_fullfield')
-    opts=['opt1']
-    path = s.get_sensor_path(TIMESTAMP, opts=opts)
-    assert path.endswith('_opt1.tif')
-
-def test_multiopts_usage():
-    s = Sensors(TERRAREF_BASE, 'ua-mac', 'Level_1', 'rgb_fullfield')
-    opts=['opt1', 'opt2', 'opt3']
-    path = s.get_sensor_path(TIMESTAMP, opts=opts)
-    assert path.endswith('_opt1_opt2_opt3.tif')
-
-def test_alt_extension():
-    s = Sensors(TERRAREF_BASE, 'ua-mac', 'Level_1', 'rgb_fullfield')
-    path = s.get_sensor_path(TIMESTAMP, ext='alt')
-    assert path.endswith('.alt')
-     


### PR DESCRIPTION
Remove the explicit use of data levels from both the sensor dictionary and as a parameter to
sensor methods. Data levels are still used in the file system but it's transparent to extractors.

Modify the create_sensor_path to match get_sensor_path in
terms of parameters but have a side effect of creating necessary
path directories.

Fix issue with submit_traits in betydb.py where it was using local
functions to set default parameter values. This had a side effect
of calling the functions during import which broke testing and
is bad practice in general.