### PR TITLE
added cfunits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cfunits==1.5.1
 influxdb==4.1.0
 matplotlib==1.5.1
 netCDF4==1.2.4


### PR DESCRIPTION
required by https://github.com/terraref/extractors-environmental/pull/25 that fixes irrigation extractor https://github.com/terraref/computing-pipeline/issues/400

Adding new package here because we should use this package instead of hard-coded numbers for all unit conversions

This is the wrapper for the udunits library, which is part of the cf-standards / netcdf ecosystem of utilities,