### PR TITLE
Add cultivars site metadata

### DIFF
--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -77,7 +77,7 @@ def get_brapi_study(studyDbId):
 
 def get_brapi_study_germplasm(studyDbId):
     URL = os.environ.get('BRAPI_URL',BRAPI_URL)
-    request_url = os.path.join(URL,'v1','studies',studyDbId,'germplasm')
+    request_url = os.path.join(URL,'v1','studies',str(studyDbId),'germplasm')
     r = requests.get(request_url)
 
     germplasm_id_data_map = {}
@@ -86,18 +86,18 @@ def get_brapi_study_germplasm(studyDbId):
        data = r.json()['result']['data']
        for entry in data:
             germplasm = {}
-            germplasm['germplasmName'] = entry['germplasmName']
-            germplasm['species'] = entry['species']
-            germplasm['genus'] = entry['genus']
-            germplasm['germplasmDbId'] = entry['germplasmDbId']
-            germplasm_id_data_map[entry['germplasmDbId']] = germplasm
+            germplasm['germplasmName'] = str(entry['germplasmName'])
+            germplasm['species'] = str(entry['species'])
+            germplasm['genus'] = str(entry['genus'])
+            germplasm['germplasmDbId'] = str(entry['germplasmDbId'])
+            germplasm_id_data_map[str(entry['germplasmDbId'])] = germplasm
     return germplasm_id_data_map
 
 
 def get_brapi_study_layouts(studyDbId):
     """return study layouts from brapi based on brapi url"""
     URL = os.environ.get('BRAPI_URL', BRAPI_URL)
-    request_url = os.path.join(URL, 'v1', 'studies', studyDbId, 'layouts')
+    request_url = os.path.join(URL, 'v1', 'studies', str(studyDbId), 'layouts')
     r = requests.get(request_url)
 
     site_id_germplasm_map = {}
@@ -105,8 +105,8 @@ def get_brapi_study_layouts(studyDbId):
     if r.status_code == 200:
         data = r.json()['result']['data']
         for entry in data:
-            site_id = entry['observationUnitDbId']
-            cultivar_id = entry['germPlasmDbId']
+            site_id = str(entry['observationUnitDbId'])
+            cultivar_id = str(entry['germPlasmDbId'])
             site_id_germplasm_map[site_id] = cultivar_id
     return site_id_germplasm_map
 

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -76,12 +76,51 @@ def get_brapi_study(studyDbId):
 
 
 def get_brapi_study_germplasm(studyDbId):
-    """return study germplasm from brapi based on brapi url"""
     URL = os.environ.get('BRAPI_URL',BRAPI_URL)
     request_url = os.path.join(URL,'v1','studies',studyDbId,'germplasm')
     r = requests.get(request_url)
-    return r.json()
 
+    germplasm_id_data_map = {}
+
+    if r.status_code == 200:
+       data = r.json()['result']['data']
+       for entry in data:
+            germplasm = {}
+            germplasm['germplasmName'] = entry['germplasmName']
+            germplasm['species'] = entry['species']
+            germplasm['genus'] = entry['genus']
+            germplasm_id_data_map[entry['germplasmDbId']] = germplasm
+    return germplasm_id_data_map
+
+
+def get_brapi_study_layouts(studyDbId):
+    """return study layouts from brapi based on brapi url"""
+    URL = os.environ.get('BRAPI_URL', BRAPI_URL)
+    request_url = os.path.join(URL, 'v1', 'studies', studyDbId, 'layouts')
+    r = requests.get(request_url)
+
+    site_id_germplasm_map = {}
+
+    if r.status_code == 200:
+        data = r.json()['result']['data']
+        for entry in data:
+            site_id = entry['observationUnitDbId']
+            cultivar_id = entry['germPlasmDbId']
+            site_id_germplasm_map[site_id] = cultivar_id
+    return site_id_germplasm_map
+
+
+def get_site_id_cultivar_info_map(studyDbId):
+    layouts = get_brapi_study_layouts(studyDbId)
+    germplasm = get_brapi_study_germplasm(studyDbId)
+
+    site_ids = layouts.keys()
+
+    for site_id in site_ids:
+        corresponding_site_cultivar_id = layouts[site_id]
+        cultivar_info_from_germplasm = germplasm[corresponding_site_cultivar_id]
+        layouts[site_id] = cultivar_info_from_germplasm
+    return layouts
 
 def get_bety_url(path=''):
     """return betydb url from environment with optional path

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -133,7 +133,7 @@ def get_experiment_observation_units_map(studyDbId):
     location_name_treatments_map = {}
     for entry in data:
         treatment = {}
-        treatment['treatment_description'] = str(entry['observationtreatment'])
+        treatment['definition'] = str(entry['observationtreatment'])
         treatment['id'] = str(entry['treatmentDbId'])
         treatment['experiment_id'] = str(entry['studyDbId'])
         location_name_treatments_map[str(entry['observationUnitName'])] = treatment

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -148,16 +148,20 @@ def get_site_id_cultivar_info_map(studyDbId):
     for site_id in site_ids:
         corresponding_site_cultivar_id = layouts[site_id]['germplasmDbId']
         corresponding_site_name = layouts[site_id]['sitename']
-        try:
-            treatment_info = observationunits[corresponding_site_name]
-            layouts[site_id]['treatment_info'] = treatment_info
-        except:
-            layouts[site_id]['treatment_info'] = "no treatment data available"
-        try:
+        if corresponding_site_name.endswith(' W'):
+            corresponding_site_name = corresponding_site_name.replace(' W', '')
+        if corresponding_site_name.endswith(' E'):
+            corresponding_site_name.replace(' E', '')
+        if corresponding_site_cultivar_id in germplasm:
             cultivar_info_from_germplasm = germplasm[corresponding_site_cultivar_id]
-            layouts[site_id]['cultivar_info'] = cultivar_info_from_germplasm
-        except:
-            layouts[site_id]['cultivar_info'] = "no cultivar data available"
+            layouts[site_id]['cultivar'] = cultivar_info_from_germplasm
+        else:
+            layouts[site_id]['cultivar'] = 'no info'
+        if corresponding_site_name in observationunits:
+            treatment_info = observationunits[corresponding_site_name]
+            layouts[site_id]['treatments'] = treatment_info
+        else:
+            layouts[site_id]['treatments'] = 'no info'
     return layouts
 
 
@@ -361,13 +365,13 @@ def get_sites(filter_date='', include_halves=False, **kwargs):
                             s['experiment_id'] = exp['id']
                             current_site_id = s['id']
                             if current_site_id in exp_site_cultivar_map:
-                                cultivar_info_for_site = exp_site_cultivar_map[s['id']]['cultivar_info']
-                                treatment_info_for_site = exp_site_cultivar_map[s['id']]['treatment_info']
+                                cultivar_info_for_site = exp_site_cultivar_map[s['id']]['cultivar']
+                                treatment_info_for_site = exp_site_cultivar_map[s['id']]['treatments']
                                 s['cultivar'] = cultivar_info_for_site
                                 s['treatments'] = treatment_info_for_site
                             else:
-                                s['cultivar'] = 'no info available'
-                                s['treatments'] = 'no info available'
+                                s['cultivar'] = 'no info'
+                                s['treatments'] = 'no info'
                             # TODO: Eventually find better solution for S4 half-plots - they are omitted here
                             if (s["sitename"].endswith(" W") or s["sitename"].endswith(" E")) and not include_halves:
                                 continue

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -278,7 +278,6 @@ def get_sites(filter_date='', include_halves=False, **kwargs):
                     if 'sites' in exp:
                         for t in exp['sites']:
                             s = t['site']
-                            # TODO add experiment id here ?
                             s['experiment_id'] = exp['id']
 
                             # TODO: Eventually find better solution for S4 half-plots - they are omitted here

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -81,6 +81,12 @@ def get_brapi_observationunits(studyDbId):
     r = requests.get(url=study_url, params=request_params)
     return r.json()
 
+def get_brapi_all_observation_units(studyDbId):
+    first_page_results = get_brapi_observationunits(studyDbId)
+    results_count = first_page_results['metadata']['pagination']['totalCount']
+    all_observation_units = get_brapi_observationunits(studyDbId, pageSize=results_count)
+    return all_observation_units
+
 def get_brapi_study_germplasm(studyDbId):
     URL = os.environ.get('BRAPI_URL',BRAPI_URL)
     request_url = os.path.join(URL,'v1','studies',str(studyDbId),'germplasm')
@@ -123,11 +129,7 @@ def get_brapi_study_layouts(studyDbId):
 
 
 def get_experiment_observation_units_map(studyDbId):
-    endpoint = 'observationunits'
-    study_url = get_brapi_api(endpoint)
-    request_params = {'studyDbId': studyDbId}
-    r = requests.get(url=study_url, params=request_params)
-    data = r.json()['result']['data']
+    data = get_brapi_all_observation_units(studyDbId)
     location_name_treatments_map = {}
     for entry in data:
         treatment = {}

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -136,7 +136,7 @@ def get_experiment_observation_units_map(studyDbId):
         treatment['treatment_description'] = str(entry['observationtreatment'])
         treatment['id'] = str(entry['treatmentDbId'])
         treatment['experiment_id'] = str(entry['studyDbId'])
-        location_name_treatments_map[str(entry['location_abbreviation'])] = treatment
+        location_name_treatments_map[str(entry['observationUnitName'])] = treatment
     return location_name_treatments_map
 
 

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -242,6 +242,9 @@ def get_sites(filter_date='', include_halves=False, **kwargs):
                     if 'sites' in exp:
                         for t in exp['sites']:
                             s = t['site']
+                            # TODO add experiment id here ?
+                            s['experiment_id'] = exp['id']
+
                             # TODO: Eventually find better solution for S4 half-plots - they are omitted here
                             if (s["sitename"].endswith(" W") or s["sitename"].endswith(" E")) and not include_halves:
                                 continue
@@ -328,3 +331,16 @@ def submit_traits(csv, filetype='csv', betykey='', betyurl=''):
     else:
         logging.error("Error submitting data to BETYdb: %s -- %s" % (resp.status_code, resp.reason))
         resp.raise_for_status()
+
+def get_experiment_id_for_site_id(site_id):
+    experiments = get_experiments()
+
+    result = None
+
+    for exp in experiments:
+        exp_sites = exp['sites']
+        for s in exp_sites:
+            current_site_id = s['experiments_site']['site_id']
+            if site_id == current_site_id:
+                result = exp['id']
+    return result

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -89,6 +89,7 @@ def get_brapi_study_germplasm(studyDbId):
             germplasm['germplasmName'] = entry['germplasmName']
             germplasm['species'] = entry['species']
             germplasm['genus'] = entry['genus']
+            germplasm['germplasmDbId'] = entry['germplasmDbId']
             germplasm_id_data_map[entry['germplasmDbId']] = germplasm
     return germplasm_id_data_map
 
@@ -311,6 +312,7 @@ def get_sites(filter_date='', include_halves=False, **kwargs):
         if query_data:
             results = []
             for exp in query_data:
+                exp_site_cultivar_map = get_site_id_cultivar_info_map(exp['id'])
                 start = datetime.strptime(exp['start_date'], '%Y-%m-%d')
                 end = datetime.strptime(exp['end_date'], '%Y-%m-%d')
                 if start <= targ_date <= end:
@@ -318,7 +320,8 @@ def get_sites(filter_date='', include_halves=False, **kwargs):
                         for t in exp['sites']:
                             s = t['site']
                             s['experiment_id'] = exp['id']
-
+                            cultivar_info_for_site = exp_site_cultivar_map[s]
+                            s['cultivar'] = cultivar_info_for_site
                             # TODO: Eventually find better solution for S4 half-plots - they are omitted here
                             if (s["sitename"].endswith(" W") or s["sitename"].endswith(" E")) and not include_halves:
                                 continue
@@ -405,23 +408,3 @@ def submit_traits(csv, filetype='csv', betykey='', betyurl=''):
     else:
         logging.error("Error submitting data to BETYdb: %s -- %s" % (resp.status_code, resp.reason))
         resp.raise_for_status()
-
-def get_germplasm_cultivar_from_brapi(studyDbId):
-    return 0
-
-def get_treatments_from_brapi(studyDbId):
-    endpoint = 'studies/'+studyDbId
-    return 0
-
-def get_experiment_id_for_site_id(site_id):
-    experiments = get_experiments()
-
-    result = None
-
-    for exp in experiments:
-        exp_sites = exp['sites']
-        for s in exp_sites:
-            current_site_id = s['experiments_site']['site_id']
-            if site_id == current_site_id:
-                result = exp['id']
-    return result

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -65,6 +65,24 @@ def get_brapi_api(endpoint=None):
     url = get_brapi_url(path='v1/{}'.format(endpoint))
     return url
 
+
+def get_brapi_study(studyDbId):
+    """return study from brapi based on brapi url"""
+    endpoint = 'studies'
+    study_url = get_brapi_api(endpoint)
+    request_params = {'studyDbId':studyDbId}
+    r = requests.get(url=study_url, params=request_params)
+    return r.json()
+
+
+def get_brapi_study_germplasm(studyDbId):
+    """return study germplasm from brapi based on brapi url"""
+    URL = os.environ.get('BRAPI_URL',BRAPI_URL)
+    request_url = os.path.join(URL,'v1','studies',studyDbId,'germplasm')
+    r = requests.get(request_url)
+    return r.json()
+
+
 def get_bety_url(path=''):
     """return betydb url from environment with optional path
 

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -11,6 +11,7 @@ import requests
 import json
 from osgeo import ogr
 
+BRAPI_URL="https://brapi.workbench.terraref.org/brapi"
 
 BETYDB_URL="https://terraref.ncsa.illinois.edu/bety"
 BETYDB_LOCAL_CACHE_FOLDER = os.environ.get('BETYDB_LOCAL_CACHE_FOLDER', '/home/extractor/')
@@ -46,6 +47,16 @@ def get_bety_key():
         raise RuntimeError("BETYDB_KEY not found. Set environmental variable "
                        "or create $HOME/.betykey.")
 
+
+def get_brapi_url(path=''):
+
+    url = os.environ['BRAPI_URL', BRAPI_URL]
+    return os.path.join(url,path)
+
+def get_brapi_api(endpoint=None):
+
+    url = get_brapi_url(path='/v1/{}'.format(endpoint))
+    return url
 
 def get_bety_url(path=''):
     """return betydb url from environment with optional path

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -49,13 +49,20 @@ def get_bety_key():
 
 
 def get_brapi_url(path=''):
+    """return brapi url from environment with optional path
 
-    url = os.environ['BRAPI_URL', BRAPI_URL]
-    return os.path.join(url,path)
+    Of 3 options string join, os.path.join and urlparse.urljoin, os.path.join
+    is the best at handling excessive / characters.
+    """
+
+    url = os.environ.get('BRAPI_URL', BRAPI_URL)
+    return os.path.join(url, path)
+
 
 def get_brapi_api(endpoint=None):
+    """return brapi API based on brapi url"""
 
-    url = get_brapi_url(path='/v1/{}'.format(endpoint))
+    url = get_brapi_url(path='v1/{}'.format(endpoint))
     return url
 
 def get_bety_url(path=''):
@@ -342,6 +349,13 @@ def submit_traits(csv, filetype='csv', betykey='', betyurl=''):
     else:
         logging.error("Error submitting data to BETYdb: %s -- %s" % (resp.status_code, resp.reason))
         resp.raise_for_status()
+
+def get_germplasm_cultivar_from_brapi(studyDbId):
+    return 0
+
+def get_treatments_from_brapi(studyDbId):
+    endpoint = 'studies/'+studyDbId
+    return 0
 
 def get_experiment_id_for_site_id(site_id):
     experiments = get_experiments()

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -74,6 +74,12 @@ def get_brapi_study(studyDbId):
     r = requests.get(url=study_url, params=request_params)
     return r.json()
 
+def get_brapi_observationunits(studyDbId):
+    endpoint = 'observationunits'
+    study_url = get_brapi_api(endpoint)
+    request_params = {'studyDbId': studyDbId}
+    r = requests.get(url=study_url, params=request_params)
+    return r.json()
 
 def get_brapi_study_germplasm(studyDbId):
     URL = os.environ.get('BRAPI_URL',BRAPI_URL)
@@ -115,17 +121,6 @@ def get_brapi_study_layouts(studyDbId):
     return site_id_germplasm_map
 
 
-def get_site_id_cultivar_info_map(studyDbId):
-    layouts = get_brapi_study_layouts(studyDbId)
-    germplasm = get_brapi_study_germplasm(studyDbId)
-
-    site_ids = layouts.keys()
-
-    for site_id in site_ids:
-        corresponding_site_cultivar_id = layouts[site_id]['germplasmDbId']
-        cultivar_info_from_germplasm = germplasm[corresponding_site_cultivar_id]
-        layouts[site_id]['cultivar_info'] = cultivar_info_from_germplasm
-    return layouts
 
 def get_experiment_observation_units_map(studyDbId):
     endpoint = 'observationunits'
@@ -141,6 +136,25 @@ def get_experiment_observation_units_map(studyDbId):
         treatment['experiment_id'] = entry['studyDbId']
         location_name_treatments_map[entry['location_abbreviation']] = treatment
     return location_name_treatments_map
+
+
+def get_site_id_cultivar_info_map(studyDbId):
+    layouts = get_brapi_study_layouts(studyDbId)
+    germplasm = get_brapi_study_germplasm(studyDbId)
+    observationunits = get_experiment_observation_units_map(studyDbId)
+
+    site_ids = layouts.keys()
+
+    for site_id in site_ids:
+        corresponding_site_cultivar_id = layouts[site_id]['germplasmDbId']
+        corresponding_site_name = layouts[site_id]['sitename']
+        treatment_info = observationunits[corresponding_site_name]
+        layouts[site_id]['treatment_info'] = treatment_info
+        cultivar_info_from_germplasm = germplasm[corresponding_site_cultivar_id]
+        layouts[site_id]['cultivar_info'] = cultivar_info_from_germplasm
+    return layouts
+
+
 
 def get_bety_url(path=''):
     """return betydb url from environment with optional path

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -74,10 +74,12 @@ def get_brapi_study(studyDbId):
     r = requests.get(url=study_url, params=request_params)
     return r.json()
 
-def get_brapi_observationunits(studyDbId):
+def get_brapi_observationunits(studyDbId, pageSize=None):
     endpoint = 'observationunits'
     study_url = get_brapi_api(endpoint)
     request_params = {'studyDbId': studyDbId}
+    if pageSize:
+        request_params['pageSize'] = pageSize
     r = requests.get(url=study_url, params=request_params)
     return r.json()
 
@@ -85,7 +87,7 @@ def get_brapi_all_observation_units(studyDbId):
     first_page_results = get_brapi_observationunits(studyDbId)
     results_count = first_page_results['metadata']['pagination']['totalCount']
     all_observation_units = get_brapi_observationunits(studyDbId, pageSize=results_count)
-    return all_observation_units
+    return all_observation_units['result']['data']
 
 def get_brapi_study_germplasm(studyDbId):
     URL = os.environ.get('BRAPI_URL',BRAPI_URL)

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -106,19 +106,19 @@ def get_brapi_study_layouts(studyDbId):
     request_url = os.path.join(URL, 'v1', 'studies', str(studyDbId), 'layouts')
     r = requests.get(request_url)
 
-    site_id_germplasm_map = {}
+    site_id_layouts_map = {}
 
     if r.status_code == 200:
         data = r.json()['result']['data']
         for entry in data:
-            site_id = int(entry['observationUnitDbId'])
+            site_id = str(entry['observationUnitDbId'])
             site_name = str(entry['observationUnitName'])
-            cultivar_id = int(entry['germPlasmDbId'])
+            cultivar_id = str(entry['germPlasmDbId'])
             site_info = {}
             site_info['sitename'] = site_name
             site_info['germplasmDbId'] = cultivar_id
-            site_id_germplasm_map[site_id] = site_info
-    return site_id_germplasm_map
+            site_id_layouts_map[site_id] = site_info
+    return site_id_layouts_map
 
 
 
@@ -131,10 +131,10 @@ def get_experiment_observation_units_map(studyDbId):
     location_name_treatments_map = {}
     for entry in data:
         treatment = {}
-        treatment['treatment_description'] = entry['observationtreatment']
-        treatment['id'] = int(entry['treatmentDbId'])
-        treatment['experiment_id'] = int(entry['studyDbId'])
-        location_name_treatments_map[entry['location_abbreviation']] = treatment
+        treatment['treatment_description'] = str(entry['observationtreatment'])
+        treatment['id'] = str(entry['treatmentDbId'])
+        treatment['experiment_id'] = str(entry['studyDbId'])
+        location_name_treatments_map[str(entry['location_abbreviation'])] = treatment
     return location_name_treatments_map
 
 

--- a/terrautils/betydb.py
+++ b/terrautils/betydb.py
@@ -354,7 +354,9 @@ def get_sites(filter_date='', include_halves=False, **kwargs):
                             s = t['site']
                             s['experiment_id'] = exp['id']
                             cultivar_info_for_site = exp_site_cultivar_map[s]['cultivar_info']
+                            treatment_info_for_site = exp_site_cultivar_map[s]['treatment_info']
                             s['cultivar'] = cultivar_info_for_site
+                            s['treatments'] = treatment_info_for_site
                             # TODO: Eventually find better solution for S4 half-plots - they are omitted here
                             if (s["sitename"].endswith(" W") or s["sitename"].endswith(" E")) and not include_halves:
                                 continue

--- a/terrautils/lemnatec.py
+++ b/terrautils/lemnatec.py
@@ -108,8 +108,6 @@ def _get_sites(cleaned_md, date, sensorId):
     """
     gps_bounds = calculate_gps_bounds(cleaned_md, sensorId)
 
-    experiments = betydb.get_experiments()
-
     sites = {}
     for label, bounds in gps_bounds.iteritems():
         centroid = calculate_centroid(bounds)
@@ -118,9 +116,11 @@ def _get_sites(cleaned_md, date, sensorId):
             site_id = str(bety_site["id"])
             sites[site_id] = {}
             sites[site_id]["sitename"] = bety_site["sitename"]
-            experiment_id = betydb.get_experiment_id_for_site_id(site_id)
-            #cultivar md
-            #treatments metadata
+            experiment_id = bety_site["experiment_id"]
+
+            site_cultivar_map = betydb.get_site_id_cultivar_info_map(experiment_id)
+            cultivar_info = site_cultivar_map[site_id]
+
             if "view_url" in bety_site:
                 sites[site_id]["url"] = bety_site["view_url"]
             else:

--- a/terrautils/lemnatec.py
+++ b/terrautils/lemnatec.py
@@ -117,6 +117,7 @@ def _get_sites(cleaned_md, date, sensorId):
             sites[site_id] = {}
             sites[site_id]["sitename"] = bety_site["sitename"]
             sites[site_id]["experiment_id"] = bety_site["experiment_id"]
+            sites[site_id]["treatments"] = bety_site["treatments"]
             sites[site_id]["cultivar"] = bety_site["cultivar"]
 
             if "view_url" in bety_site:

--- a/terrautils/lemnatec.py
+++ b/terrautils/lemnatec.py
@@ -116,6 +116,7 @@ def _get_sites(cleaned_md, date, sensorId):
             site_id = str(bety_site["id"])
             sites[site_id] = {}
             sites[site_id]["sitename"] = bety_site["sitename"]
+            # TODO add other metadata from betydb here
             if "view_url" in bety_site:
                 sites[site_id]["url"] = bety_site["view_url"]
             else:

--- a/terrautils/lemnatec.py
+++ b/terrautils/lemnatec.py
@@ -116,10 +116,8 @@ def _get_sites(cleaned_md, date, sensorId):
             site_id = str(bety_site["id"])
             sites[site_id] = {}
             sites[site_id]["sitename"] = bety_site["sitename"]
-            experiment_id = bety_site["experiment_id"]
-
-            site_cultivar_map = betydb.get_site_id_cultivar_info_map(experiment_id)
-            cultivar_info = site_cultivar_map[site_id]
+            sites[site_id]["experiment_id"] = bety_site["experiment_id"]
+            sites[site_id]["cultivar"] = bety_site["cultivar"]
 
             if "view_url" in bety_site:
                 sites[site_id]["url"] = bety_site["view_url"]

--- a/terrautils/lemnatec.py
+++ b/terrautils/lemnatec.py
@@ -108,6 +108,8 @@ def _get_sites(cleaned_md, date, sensorId):
     """
     gps_bounds = calculate_gps_bounds(cleaned_md, sensorId)
 
+    experiments = betydb.get_experiments()
+
     sites = {}
     for label, bounds in gps_bounds.iteritems():
         centroid = calculate_centroid(bounds)
@@ -116,7 +118,9 @@ def _get_sites(cleaned_md, date, sensorId):
             site_id = str(bety_site["id"])
             sites[site_id] = {}
             sites[site_id]["sitename"] = bety_site["sitename"]
-            # TODO add other metadata from betydb here
+            experiment_id = betydb.get_experiment_id_for_site_id(site_id)
+            #cultivar md
+            #treatments metadata
             if "view_url" in bety_site:
                 sites[site_id]["url"] = bety_site["view_url"]
             else:


### PR DESCRIPTION
This pull request is dependent on this pull request in brapi

https://github.com/terraref/brapi/pull/31

It resolves this issue

https://github.com/terraref/computing-pipeline/issues/573

The following changes have been made.

In the class betydb new methods are added to make calls to brapi studies, layouts, germplasm and observationunits endpoints. 

betydb.get_sites now includes info on the sites, cultivars and treatments for each site.

in lemnatec._get_sites this new metadata for cultivar and treatments is added to the site metadata. 

