### PR TITLE
Fix site metadata formatting

### DIFF
--- a/terrautils/lemnatec.py
+++ b/terrautils/lemnatec.py
@@ -113,16 +113,15 @@ def _get_sites(cleaned_md, date, sensorId):
         centroid = calculate_centroid(bounds)
         bety_sites = terrautils.betydb.get_sites_by_latlon(centroid, date)
         for bety_site in bety_sites:
-            site_id = str(bety_site["id"])
-            sites[site_id] = {}
-            sites[site_id]["sitename"] = bety_site["sitename"]
+            sites['id'] = str(bety_site["id"])
+            sites['notes'] = "plot that contains the image centroid"
+            sites["sitename"] = bety_site["sitename"]
             if "view_url" in bety_site:
-                sites[site_id]["url"] = bety_site["view_url"]
+                sites["url"] = bety_site["view_url"]
             else:
-                sites[site_id]["url"] = ""
-            sites['notes'] = "sitename is the plot that contains the image centroid"
+                sites["url"] = ""
 
-    return sites.values()
+    return sites
 
 
 def _get_experiment_metadata(date, sensorId): 


### PR DESCRIPTION
Write the "centroid" note as a parameter. Before it would erroneously create structure:
```
site_metadata: {
"site location is centroid",
{"sitename" <plot>, ...}
}
```

Basically it would be an array of (string, dict) instead of being a dict. This should fix this issue, I also have a mongo query to fix existing cases:

```
db.datasets.find().forEach(function (ds) {
		db.metadata.find({
			"attachedTo._id": ds._id, "creator.name": extract_name,
			"content.site_metadata": {"$exists": true}
		}).forEach(function (md) {
			if (md.content.site_metadata[0] != null) {
				if (md.content.site_metadata[0].sitename == null) {
					var plot = md.content.site_metadata[1].sitename.replace(" E", "").replace(" W", "");
				} else {
					var plot = md.content.site_metadata[0].sitename.replace(" E", "").replace(" W", "");
				}
				var range = parseInt(plot.substring(plot.indexOf("Range ") + 6, plot.indexOf("Column")));
				var col = parseInt(plot.substring(plot.indexOf("Column") + 6, plot.length));
				db.metadata.update({"_id": md._id}, {
					"$set": {
						"content.site_metadata": {
							"sitename": plot,
							"season": "Season 6",
							"range": range,
							"col": col,
							"notes": "plot that contains image centroid"
						}
					}
				});
				print(ds._id.valueOf());
			}
		});
	});
```